### PR TITLE
Suppress config deprecations by setting values explicitly

### DIFF
--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -44,6 +44,10 @@ class TailwindTestKernel extends Kernel
                     __DIR__.'/assets',
                 ],
             ],
+            'handle_all_throwables' => true,
+            'php_errors' => [
+                'log' => true,
+            ],
         ]);
 
         $container->loadFromExtension('symfonycasts_tailwind', [


### PR DESCRIPTION
Fix failed tests discovered in #19

```
Remaining indirect deprecation notices (4)

  2x: Since symfony/framework-bundle 6.4: Not setting the "framework.handle_all_throwables" config option is deprecated. It will default to "true" in 7.0.
    2x in FunctionalTest::testBuiltCSSFileIsUsed from Symfonycasts\TailwindBundle\Tests

  2x: Since symfony/framework-bundle 6.4: Not setting the "framework.php_errors.log" config option is deprecated. It will default to "true" in 7.0.
    2x in FunctionalTest::testBuiltCSSFileIsUsed from Symfonycasts\TailwindBundle\Tests

```