### PR TITLE
feat: add --minify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When you deploy, run the `tailwind:build` command *before* the `asset-map:compil
 command so the built file is available:
 
 ```bash
-php bin/console tailwind:build
+php bin/console tailwind:build --minify
 php bin/console asset-map:compile
 ```
 

--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -12,6 +12,7 @@ namespace Symfonycasts\TailwindBundle\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
@@ -30,7 +31,10 @@ class TailwindBuildCommand extends Command
 
     protected function configure(): void
     {
-        $this->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically');
+        $this
+            ->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically')
+            ->addOption('minify', 'm', InputOption::VALUE_NONE, 'Minify the output CSS')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -39,7 +43,8 @@ class TailwindBuildCommand extends Command
         $this->tailwindBuilder->setOutput($io);
 
         $process = $this->tailwindBuilder->runBuild(
-            $input->getOption('watch'),
+            watch: $input->getOption('watch'),
+            minify: $input->getOption('minify'),
         );
         $process->wait(function ($type, $buffer) use ($io) {
             $io->write($buffer);

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -17,6 +17,8 @@ use Symfony\Component\Process\Process;
  * Manages the process of executing Tailwind on the input file.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @final
  */
 class TailwindBuilder
 {
@@ -40,12 +42,17 @@ class TailwindBuilder
         }
     }
 
-    public function runBuild(bool $watch): Process
-    {
+    public function runBuild(
+        bool $watch,
+        bool $minify,
+    ): Process {
         $binary = $this->createBinary();
         $arguments = ['-i', $this->inputPath, '-o', $this->getInternalOutputCssPath()];
         if ($watch) {
             $arguments[] = '--watch';
+        }
+        if ($minify) {
+            $arguments[] = '--minify';
         }
         $process = $binary->createProcess($arguments);
         if ($watch) {

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -34,17 +34,37 @@ class TailwindBuilderTest extends TestCase
         }
     }
 
-    public function testIntegration(): void
+    public function testIntegrationWithDefaultOptions(): void
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
             __DIR__.'/fixtures/assets/styles/app.css',
             __DIR__.'/fixtures/var/tailwind'
         );
-        $process = $builder->runBuild(false);
+        $process = $builder->runBuild(watch: false, minify: false);
         $process->wait();
 
         $this->assertTrue($process->isSuccessful());
         $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $this->assertStringContainsString("body {\n  background-color: red;\n}", $outputFileContents, 'The output file should contain non-minified CSS.');
+    }
+
+    public function testIntegrationWithMinify(): void
+    {
+        $builder = new TailwindBuilder(
+            __DIR__.'/fixtures',
+            __DIR__.'/fixtures/assets/styles/app.css',
+            __DIR__.'/fixtures/var/tailwind'
+        );
+        $process = $builder->runBuild(watch: false, minify: true);
+        $process->wait();
+
+        $this->assertTrue($process->isSuccessful());
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $this->assertStringContainsString('body{background-color:red}', $outputFileContents, 'The output file should contain minified CSS.');
     }
 }

--- a/tests/fixtures/assets/styles/app.css
+++ b/tests/fixtures/assets/styles/app.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+    background-color: red;
+}


### PR DESCRIPTION
Hi, this PR implements the `--minify` option of the standalone Tailwind binary.

Even if the [AssetMapper documentation](https://symfony.com/doc/current/frontend/asset_mapper.html#optimizing-performance) says that we can auto-minify generated assets by Cloudflare (or other CDNs), 
I think it's nice to have the possibility to minify Tailwind's output CSS file if we are not using any CDN.