### PR TITLE
Allow working with multiple entrypoints

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -151,15 +151,16 @@ To see the full config from this bundle, run:
 
     $ php bin/console config:dump symfonycasts_tailwind
 
-The main option is ``input_css`` option, which defaults to ``assets/styles/app.css``.
-This represents the "source" Tailwind file (the one that contains the ``@tailwind``
+The main option is ``input`` option, which defaults to ``assets/styles/app.css``.
+This represents the "source" Tailwind files (the one that contains the ``@tailwind``
 directives):
 
 .. code-block:: yaml
 
     # config/packages/symfonycasts_tailwind.yaml
     symfonycasts_tailwind:
-        input_css: 'assets/styles/other.css'
+        input:
+            - 'assets/styles/other.css'
 
 Another option is the ``config_file`` option, which defaults to ``tailwind.config.js``.
 This represents the Tailwind configuration file:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -94,9 +94,11 @@ download the correct Tailwind binary for your system into a ``var/tailwind/``
 directory.
 
 When you run ``tailwind:build``, that binary is used to compile
-your CSS file into a ``var/tailwind/tailwind.built.css`` file. Finally,
-when the contents of ``assets/styles/app.css`` is requested, the bundle
-swaps the contents of that file with the contents of ``var/tailwind/tailwind.built.css``.
+each CSS file into a ``var/tailwind/<filename>.built.css`` file.
+Finally, when the contents of the CSS file is requested, the bundle swaps the
+contents of that file with the contents of ``var/tailwind/<filename>.built.css``.
+
+E.g. : A request for ``assets/styles/app.css`` will be replaced by ``var/tailwind/app.built.css``.
 Nice!
 
 Deploying

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -151,7 +151,7 @@ To see the full config from this bundle, run:
 
     $ php bin/console config:dump symfonycasts_tailwind
 
-The main option is ``input`` option, which defaults to ``assets/styles/app.css``.
+The main option is ``input_css`` option, which defaults to ``assets/styles/app.css``.
 This represents the "source" Tailwind files (the one that contains the ``@tailwind``
 directives):
 
@@ -159,8 +159,16 @@ directives):
 
     # config/packages/symfonycasts_tailwind.yaml
     symfonycasts_tailwind:
-        input:
-            - 'assets/styles/other.css'
+        input_css: 'assets/styles/other.css'
+
+It's possible to use multiple input files by providing an array:
+.. code-block:: yaml
+
+        # config/packages/symfonycasts_tailwind.yaml
+        symfonycasts_tailwind:
+            input_css:
+                - 'assets/styles/other.css'
+                - 'assets/styles/another.css'
 
 Another option is the ``config_file`` option, which defaults to ``tailwind.config.js``.
 This represents the Tailwind configuration file:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,6 @@ parameters:
         - src
     ignoreErrors:
         -
-            message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:scalarNode\\(\\)\\.$#"
+            message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:beforeNormalization\\(\\)\\.$#"
             count: 1
             path: src/DependencyInjection/TailwindExtension.php

--- a/src/AssetMapper/TailwindCssAssetCompiler.php
+++ b/src/AssetMapper/TailwindCssAssetCompiler.php
@@ -25,7 +25,7 @@ class TailwindCssAssetCompiler implements AssetCompilerInterface
 
     public function supports(MappedAsset $asset): bool
     {
-        return in_array(
+        return \in_array(
             realpath($asset->sourcePath),
             array_map('realpath', $this->tailwindBuilder->getInputCssPaths())
         );

--- a/src/AssetMapper/TailwindCssAssetCompiler.php
+++ b/src/AssetMapper/TailwindCssAssetCompiler.php
@@ -25,13 +25,16 @@ class TailwindCssAssetCompiler implements AssetCompilerInterface
 
     public function supports(MappedAsset $asset): bool
     {
-        return realpath($asset->sourcePath) === realpath($this->tailwindBuilder->getInputCssPath());
+        return in_array(
+            realpath($asset->sourcePath),
+            array_map('realpath', $this->tailwindBuilder->getInputCssPaths())
+        );
     }
 
     public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string
     {
-        $asset->addFileDependency($this->tailwindBuilder->getInternalOutputCssPath());
+        $asset->addFileDependency($this->tailwindBuilder->getInternalOutputCssPath($asset->sourcePath));
 
-        return $this->tailwindBuilder->getOutputCssContent();
+        return $this->tailwindBuilder->getOutputCssContent($asset->sourcePath);
     }
 }

--- a/src/AssetMapper/TailwindCssAssetCompiler.php
+++ b/src/AssetMapper/TailwindCssAssetCompiler.php
@@ -27,7 +27,7 @@ class TailwindCssAssetCompiler implements AssetCompilerInterface
     {
         return \in_array(
             realpath($asset->sourcePath),
-            array_map('realpath', $this->tailwindBuilder->getInputCssPaths())
+            $this->tailwindBuilder->getInputCssPaths(),
         );
     }
 

--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -11,6 +11,7 @@ namespace Symfonycasts\TailwindBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,7 +33,7 @@ class TailwindBuildCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addOption('input', 'i', InputOption::VALUE_OPTIONAL, 'The input CSS file')
+            ->addArgument('input', InputArgument::OPTIONAL, 'The input CSS file to compile')
             ->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically')
             ->addOption('poll', null, null, 'Use polling instead of filesystem events when watching')
             ->addOption('minify', 'm', InputOption::VALUE_NONE, 'Minify the output CSS')
@@ -48,7 +49,7 @@ class TailwindBuildCommand extends Command
             watch: $input->getOption('watch'),
             poll: $input->getOption('poll'),
             minify: $input->getOption('minify'),
-            inputFile: $input->getOption('input'),
+            inputFile: $input->getArgument('input'),
         );
         $process->wait(function ($type, $buffer) use ($io) {
             $io->write($buffer);

--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -32,6 +32,7 @@ class TailwindBuildCommand extends Command
     protected function configure(): void
     {
         $this
+            ->addOption('input', 'i', InputOption::VALUE_OPTIONAL, 'The input CSS file')
             ->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically')
             ->addOption('poll', null, null, 'Use polling instead of filesystem events when watching')
             ->addOption('minify', 'm', InputOption::VALUE_NONE, 'Minify the output CSS')
@@ -47,6 +48,7 @@ class TailwindBuildCommand extends Command
             watch: $input->getOption('watch'),
             poll: $input->getOption('poll'),
             minify: $input->getOption('minify'),
+            inputFile: $input->getOption('input'),
         );
         $process->wait(function ($type, $buffer) use ($io) {
             $io->write($buffer);

--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -33,7 +33,7 @@ class TailwindBuildCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('input', InputArgument::OPTIONAL, 'The input CSS file to compile')
+            ->addArgument('input_css', InputArgument::OPTIONAL, 'The input CSS file to compile')
             ->addOption('watch', 'w', null, 'Watch for changes and rebuild automatically')
             ->addOption('poll', null, null, 'Use polling instead of filesystem events when watching')
             ->addOption('minify', 'm', InputOption::VALUE_NONE, 'Minify the output CSS')
@@ -49,7 +49,7 @@ class TailwindBuildCommand extends Command
             watch: $input->getOption('watch'),
             poll: $input->getOption('poll'),
             minify: $input->getOption('minify'),
-            inputFile: $input->getArgument('input'),
+            inputFile: $input->getArgument('input_css'),
         );
         $process->wait(function ($type, $buffer) use ($io) {
             $io->write($buffer);

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -92,7 +92,7 @@ class TailwindInitCommand extends Command
 
     private function addTailwindDirectives(SymfonyStyle $io): void
     {
-        $inputFile = $this->tailwindBuilder->getInputCssPath();
+        $inputFile = $this->tailwindBuilder->getInputCssPaths()[0];
         $contents = is_file($inputFile) ? file_get_contents($inputFile) : '';
         if (str_contains($contents, '@tailwind base')) {
             $io->note(sprintf('Tailwind directives already exist in "%s"', $inputFile));

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -55,6 +55,7 @@ class TailwindExtension extends Extension implements ConfigurationInterface
             ->children()
                 ->arrayNode('input_css')
                     ->prototype('scalar')->end()
+                    ->beforeNormalization()->castToArray()->end()
                     ->info('Paths to CSS files to process through Tailwind')
                     ->defaultValue(['%kernel.project_dir%/assets/styles/app.css'])
                 ->end()

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -53,9 +53,10 @@ class TailwindExtension extends Extension implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('input_css')
-                    ->info('Path to CSS file to process through Tailwind')
-                    ->defaultValue('%kernel.project_dir%/assets/styles/app.css')
+                ->arrayNode('input_css')
+                    ->prototype('scalar')->end()
+                    ->info('Paths to CSS files to process through Tailwind')
+                    ->defaultValue(['%kernel.project_dir%/assets/styles/app.css'])
                 ->end()
                 ->scalarNode('config_file')
                     ->info('Path to the tailwind.config.js file')

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -44,15 +44,15 @@ class TailwindBuilder
     }
 
     public function runBuild(
-        bool    $watch,
-        bool    $poll,
-        bool    $minify,
+        bool $watch,
+        bool $poll,
+        bool $minify,
         ?string $inputFile = null,
     ): Process {
         $binary = $this->createBinary();
 
         $inputPath = realpath($this->validateInputFile($inputFile ?? $this->inputPaths[0]));
-        if (!in_array($inputPath, $this->inputPaths)) {
+        if (!\in_array($inputPath, $this->inputPaths)) {
             throw new \InvalidArgumentException(sprintf('The input CSS file "%s" is not one of the configured input files.', $inputPath));
         }
 
@@ -108,7 +108,8 @@ class TailwindBuilder
 
     public function getInternalOutputCssPath(string $inputPath): string
     {
-        $inputFileName = pathinfo($inputPath, PATHINFO_FILENAME);
+        $inputFileName = pathinfo($inputPath, \PATHINFO_FILENAME);
+
         return "{$this->tailwindVarDir}/{$inputFileName}.built.css";
     }
 

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -24,35 +24,39 @@ use Symfony\Contracts\Cache\CacheInterface;
 class TailwindBuilder
 {
     private ?SymfonyStyle $output = null;
-    private readonly string $inputPath;
+    private readonly array $inputPaths;
 
     public function __construct(
         private readonly string $projectRootDir,
-        string $inputPath,
+        array $inputPaths,
         private readonly string $tailwindVarDir,
         private CacheInterface $cache,
         private readonly ?string $binaryPath = null,
         private readonly ?string $binaryVersion = null,
         private readonly string $configPath = 'tailwind.config.js'
     ) {
-        if (is_file($inputPath)) {
-            $this->inputPath = $inputPath;
-        } else {
-            $this->inputPath = $projectRootDir.'/'.$inputPath;
-
-            if (!is_file($this->inputPath)) {
-                throw new \InvalidArgumentException(sprintf('The input CSS file "%s" does not exist.', $inputPath));
-            }
+        $paths = [];
+        foreach ($inputPaths as $inputPath) {
+            $paths[] = $this->validateInputFile($inputPath);
         }
+
+        $this->inputPaths = $paths;
     }
 
     public function runBuild(
-        bool $watch,
-        bool $poll,
-        bool $minify,
+        bool    $watch,
+        bool    $poll,
+        bool    $minify,
+        ?string $inputFile = null,
     ): Process {
         $binary = $this->createBinary();
-        $arguments = ['-c', $this->configPath, '-i', $this->inputPath, '-o', $this->getInternalOutputCssPath()];
+
+        $inputPath = $this->validateInputFile($inputFile ?? $this->inputPaths[0]);
+        if (!in_array($inputPath, $this->inputPaths)) {
+            throw new \InvalidArgumentException(sprintf('The input CSS file "%s" is not one of the configured input files.', $inputPath));
+        }
+
+        $arguments = ['-c', $this->configPath, '-i', $inputPath, '-o', $this->getInternalOutputCssPath($inputPath)];
         if ($watch) {
             $arguments[] = '--watch';
             if ($poll) {
@@ -102,14 +106,15 @@ class TailwindBuilder
         $this->output = $output;
     }
 
-    public function getInternalOutputCssPath(): string
+    public function getInternalOutputCssPath(string $inputPath): string
     {
-        return $this->tailwindVarDir.'/tailwind.built.css';
+        $inputFileName = pathinfo($inputPath, PATHINFO_FILENAME);
+        return "{$this->tailwindVarDir}/{$inputFileName}.built.css";
     }
 
-    public function getInputCssPath(): string
+    public function getInputCssPaths(): array
     {
-        return $this->inputPath;
+        return $this->inputPaths;
     }
 
     public function getConfigFilePath(): string
@@ -117,13 +122,26 @@ class TailwindBuilder
         return $this->configPath;
     }
 
-    public function getOutputCssContent(): string
+    public function getOutputCssContent(?string $inputFile = null): string
     {
-        if (!is_file($this->getInternalOutputCssPath())) {
+        if (!is_file($this->getInternalOutputCssPath($inputFile))) {
             throw new \RuntimeException('Built Tailwind CSS file does not exist: run "php bin/console tailwind:build" to generate it');
         }
 
-        return file_get_contents($this->getInternalOutputCssPath());
+        return file_get_contents($this->getInternalOutputCssPath($inputFile));
+    }
+
+    private function validateInputFile(string $inputPath): string
+    {
+        if (is_file($inputPath)) {
+            return $inputPath;
+        }
+
+        if (is_file($this->projectRootDir.'/'.$inputPath)) {
+            return $this->projectRootDir.'/'.$inputPath;
+        }
+
+        throw new \InvalidArgumentException(sprintf('The input CSS file "%s" does not exist.', $inputPath));
     }
 
     private function createBinary(): TailwindBinary

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -123,7 +123,7 @@ class TailwindBuilder
         return $this->configPath;
     }
 
-    public function getOutputCssContent(?string $inputFile = null): string
+    public function getOutputCssContent(string $inputFile): string
     {
         if (!is_file($this->getInternalOutputCssPath($inputFile))) {
             throw new \RuntimeException('Built Tailwind CSS file does not exist: run "php bin/console tailwind:build" to generate it');

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -51,7 +51,7 @@ class TailwindBuilder
     ): Process {
         $binary = $this->createBinary();
 
-        $inputPath = $this->validateInputFile($inputFile ?? $this->inputPaths[0]);
+        $inputPath = realpath($this->validateInputFile($inputFile ?? $this->inputPaths[0]));
         if (!in_array($inputPath, $this->inputPaths)) {
             throw new \InvalidArgumentException(sprintf('The input CSS file "%s" is not one of the configured input files.', $inputPath));
         }
@@ -86,7 +86,7 @@ class TailwindBuilder
         return $process;
     }
 
-    public function runInit()
+    public function runInit(): Process
     {
         $binary = $this->createBinary();
         $process = $binary->createProcess(['init']);

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -51,7 +51,7 @@ class TailwindBuilder
     ): Process {
         $binary = $this->createBinary();
 
-        $inputPath = realpath($this->validateInputFile($inputFile ?? $this->inputPaths[0]));
+        $inputPath = $this->validateInputFile($inputFile ?? $this->inputPaths[0]);
         if (!\in_array($inputPath, $this->inputPaths)) {
             throw new \InvalidArgumentException(sprintf('The input CSS file "%s" is not one of the configured input files.', $inputPath));
         }
@@ -135,11 +135,11 @@ class TailwindBuilder
     private function validateInputFile(string $inputPath): string
     {
         if (is_file($inputPath)) {
-            return $inputPath;
+            return realpath($inputPath);
         }
 
         if (is_file($this->projectRootDir.'/'.$inputPath)) {
-            return $this->projectRootDir.'/'.$inputPath;
+            return realpath($this->projectRootDir.'/'.$inputPath);
         }
 
         throw new \InvalidArgumentException(sprintf('The input CSS file "%s" does not exist.', $inputPath));

--- a/tests/AssetMapper/TailwindCssAssetCompilerTest.php
+++ b/tests/AssetMapper/TailwindCssAssetCompilerTest.php
@@ -21,8 +21,8 @@ class TailwindCssAssetCompilerTest extends TestCase
     {
         $builder = $this->createMock(TailwindBuilder::class);
         $builder->expects($this->any())
-            ->method('getInputCssPath')
-            ->willReturn(__DIR__.'/../fixtures/assets/styles/app.css');
+            ->method('getInputCssPaths')
+            ->willReturn([__DIR__.'/../fixtures/assets/styles/app.css']);
         $builder->expects($this->once())
             ->method('getInternalOutputCssPath');
         $builder->expects($this->once())

--- a/tests/AssetMapper/TailwindCssAssetCompilerTest.php
+++ b/tests/AssetMapper/TailwindCssAssetCompilerTest.php
@@ -22,7 +22,7 @@ class TailwindCssAssetCompilerTest extends TestCase
         $builder = $this->createMock(TailwindBuilder::class);
         $builder->expects($this->any())
             ->method('getInputCssPaths')
-            ->willReturn([\dirname(__DIR__).'/fixtures/assets/styles/app.css']);
+            ->willReturn([realpath(__DIR__.'/../fixtures/assets/styles/app.css')]);
         $builder->expects($this->once())
             ->method('getInternalOutputCssPath');
         $builder->expects($this->once())

--- a/tests/AssetMapper/TailwindCssAssetCompilerTest.php
+++ b/tests/AssetMapper/TailwindCssAssetCompilerTest.php
@@ -22,7 +22,7 @@ class TailwindCssAssetCompilerTest extends TestCase
         $builder = $this->createMock(TailwindBuilder::class);
         $builder->expects($this->any())
             ->method('getInputCssPaths')
-            ->willReturn([__DIR__.'/../fixtures/assets/styles/app.css']);
+            ->willReturn([\dirname(__DIR__).'/fixtures/assets/styles/app.css']);
         $builder->expects($this->once())
             ->method('getInternalOutputCssPath');
         $builder->expects($this->once())

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -24,7 +24,7 @@ class FunctionalTest extends KernelTestCase
             $fs->remove($tailwindVarDir);
         }
         $fs->mkdir($tailwindVarDir);
-        file_put_contents($tailwindVarDir.'/tailwind.built.css', <<<EOF
+        file_put_contents($tailwindVarDir.'/app.built.css', <<<EOF
         body {
             padding: 17px;
             background-image: url('../images/penguin.png');
@@ -35,8 +35,8 @@ class FunctionalTest extends KernelTestCase
 
     protected function tearDown(): void
     {
-        if (is_file(__DIR__.'/fixtures/var/tailwind/tailwind.built.css')) {
-            unlink(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        if (is_file(__DIR__.'/fixtures/var/tailwind/app.built.css')) {
+            unlink(__DIR__.'/fixtures/var/tailwind/app.built.css');
         }
     }
 

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -39,7 +39,7 @@ class TailwindBuilderTest extends TestCase
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
-            __DIR__.'/fixtures/assets/styles/app.css',
+            [__DIR__.'/fixtures/assets/styles/app.css'],
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
@@ -50,9 +50,9 @@ class TailwindBuilderTest extends TestCase
         $process->wait();
 
         $this->assertTrue($process->isSuccessful());
-        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/app.built.css');
 
-        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/app.built.css');
         $this->assertStringContainsString("body {\n  background-color: red;\n}", $outputFileContents, 'The output file should contain non-minified CSS.');
     }
 
@@ -60,7 +60,7 @@ class TailwindBuilderTest extends TestCase
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
-            __DIR__.'/fixtures/assets/styles/app.css',
+            [__DIR__.'/fixtures/assets/styles/app.css'],
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
@@ -71,9 +71,30 @@ class TailwindBuilderTest extends TestCase
         $process->wait();
 
         $this->assertTrue($process->isSuccessful());
-        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/app.built.css');
 
-        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/tailwind.built.css');
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/app.built.css');
         $this->assertStringContainsString('body{background-color:red}', $outputFileContents, 'The output file should contain minified CSS.');
+    }
+
+    public function testBuildProvidedInputFile(): void
+    {
+        $builder = new TailwindBuilder(
+            __DIR__.'/fixtures',
+            [__DIR__.'/fixtures/assets/styles/app.css', __DIR__.'/fixtures/assets/styles/second.css'],
+            __DIR__.'/fixtures/var/tailwind',
+            new ArrayAdapter(),
+            null,
+            null,
+            __DIR__.'/fixtures/tailwind.config.js'
+        );
+        $process = $builder->runBuild(watch: false, poll: false, minify: true, inputFile: 'assets/styles/second.css');
+        $process->wait();
+
+        $this->assertTrue($process->isSuccessful());
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/second.built.css');
+
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/second.built.css');
+        $this->assertStringContainsString('body{background-color:blue}', $outputFileContents, 'The output file should contain minified CSS.');
     }
 }

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -51,7 +51,7 @@ class TailwindTestKernel extends Kernel
         ]);
 
         $container->loadFromExtension('symfonycasts_tailwind', [
-            'input_css' => __DIR__.'/assets/styles/app.css',
+            'input_css' => [__DIR__.'/assets/styles/app.css'],
         ]);
     }
 

--- a/tests/fixtures/assets/styles/second.css
+++ b/tests/fixtures/assets/styles/second.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+    background-color: blue;
+}


### PR DESCRIPTION
This PR proposes a fix for issues #45 and #46, addressing the need to pass multiple entrypoints as an array to the tailwind builder. 

```yaml
symfonycasts_tailwind:
    input_css:
        - '%kernel.project_dir%/assets/styles/index.css'
        - '%kernel.project_dir%/assets/styles/custom.css'
```

With this enhancement, users can now specify multiple entrypoints by providing an array of file paths. When building, the entrypoint name should be passed to the command. If omitted, it defaults to the first entrypoint specified in the configuration.

This change enables the following behavior:
- `bin/console tailwind:build assets/styles/custom.css` will build the provided CSS file.
- `bin/console tailwind:build` will build `assets/styles/index.css`.

Additionally, the default `tailwind.built.css` file is no longer generated. Instead, each entrypoint is compiled to a file named based on the original entrypoint name. For example, `index.built.css` for `index.css` and `custom.built.css` for `custom.css`.

For BC compatibility, the `input_css` still accepts a string value and requires no changes from the developer

Feedback and improvement ideas are welcomed. Thank you!