### PR TITLE
fix: new asset-mapper hash

### DIFF
--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -50,6 +50,6 @@ class FunctionalTest extends KernelTestCase
         $this->assertInstanceOf(MappedAsset::class, $asset);
         $this->assertStringContainsString('padding: 17px', $asset->content);
         // verify the core CSS compiler that handles url() was executed
-        $this->assertMatchesRegularExpression('/penguin-[a-f0-9]{32}\.png/', $asset->content);
+        $this->assertMatchesRegularExpression('/penguin-[a-f0-9]{32}|[\w\d-]{7}\.png/', $asset->content);
     }
 }


### PR DESCRIPTION
Symfony 7.2 updated the hash calculation used by asset-mapper (https://github.com/symfony/symfony/pull/57879). This updates the test to account for this.