### PR TITLE
Update usage example to move the input file outside of the stylesheets block

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,9 +38,12 @@ you already have this:
 
     {# templates/base.html.twig #}
 
-    {% block stylesheets %}
-        <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
-    {% endblock %}
+    <head>
+    ...
+    <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
+    {% block stylesheets %}{% endblock %}
+    ...
+    </head>
 
 The bundle works by automatically swapping out the contents of ``styles/app.css``
 with the compiled CSS. For this to work, you need to run the ``tailwind:build``


### PR DESCRIPTION
In this example, `styles/app.css` is included in the `stylesheets` block in `base.html.twig`. However, when other templates extend this base file and add their own stylesheets, they will override the `styles/app.css` unless they explicitly include `{{ parent() }}` in the block.

To avoid this, I suggest moving `styles/app.css` outside the `stylesheets` block so that it's always included by default, and the block remains dedicated to page-specific styles.