### PR TITLE
[CI] Fix randomly failed tests on Windows

### DIFF
--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -26,8 +26,10 @@ class TailwindBuilderTest extends TestCase
                 $fs->remove(__DIR__.'/fixtures/var/tailwind');
             } catch (IOException $e) {
                 // Sometimes "Permission denied" error happens on Windows,
-                // ignore it but print a warning
-                $this->addWarning('Could not remove the temporary tailwind/ dir: '.$e->getMessage());
+                // add a warning about it and try again in a second
+                $this->addWarning('Could not remove the temporary tailwind/ dir from the time: '.$e->getMessage());
+                sleep(1);
+                $fs->remove(__DIR__.'/fixtures/var/tailwind');
             }
         }
         $fs->mkdir(__DIR__.'/fixtures/var/tailwind');

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -11,6 +11,7 @@ namespace Symfonycasts\TailwindBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
@@ -21,7 +22,13 @@ class TailwindBuilderTest extends TestCase
     {
         $fs = new Filesystem();
         if (file_exists(__DIR__.'/fixtures/var/tailwind')) {
-            $fs->remove(__DIR__.'/fixtures/var/tailwind');
+            try {
+                $fs->remove(__DIR__.'/fixtures/var/tailwind');
+            } catch (IOException $e) {
+                // Sometimes "Permission denied" error happens on Windows,
+                // ignore it but print a warning
+                $this->addWarning('Could not remove the temporary tailwind/ dir: '.$e->getMessage());
+            }
         }
         $fs->mkdir(__DIR__.'/fixtures/var/tailwind');
     }


### PR DESCRIPTION
Sometimes we have random test failures on Windows, see https://github.com/SymfonyCasts/tailwind-bundle/actions/runs/11490280966/job/31980693499

```
1) Symfonycasts\TailwindBundle\Tests\TailwindBuilderTest::testBuildProvidedInputFile
Symfony\Component\Filesystem\Exception\IOException: Failed to remove file "D:\a\tailwind-bundle\tailwind-bundle\tests/fixtures/var/tailwind\v3.4.14\tailwindcss-windows-x64.exe": unlink(D:\a\tailwind-bundle\tailwind-bundle\tests/fixtures/var/tailwind\v3.4.14\tailwindcss-windows-x64.exe): Permission denied

D:\a\tailwind-bundle\tailwind-bundle\vendor\symfony\filesystem\Filesystem.php:202
D:\a\tailwind-bundle\tailwind-bundle\vendor\symfony\filesystem\Filesystem.php:190
D:\a\tailwind-bundle\tailwind-bundle\vendor\symfony\filesystem\Filesystem.php:190
D:\a\tailwind-bundle\tailwind-bundle\vendor\symfony\filesystem\Filesystem.php:158
D:\a\tailwind-bundle\tailwind-bundle\tests\TailwindBuilderTest.php:24
D:\a\tailwind-bundle\tailwind-bundle\vendor\phpunit\phpunit\src\Framework\TestResult.php:[72](https://github.com/SymfonyCasts/tailwind-bundle/actions/runs/11490280966/job/31980693499#step:5:73)8
D:\a\tailwind-bundle\tailwind-bundle\vendor\phpunit\phpunit\src\Framework\TestSuite.php:684
D:\a\tailwind-bundle\tailwind-bundle\vendor\phpunit\phpunit\src\Framework\TestSuite.php:684
D:\a\tailwind-bundle\tailwind-bundle\vendor\phpunit\phpunit\src\Framework\TestSuite.php:684
D:\a\tailwind-bundle\tailwind-bundle\vendor\phpunit\phpunit\src\TextUI\TestRunner.php:653
```

Probably this will help? Thoughts?

I think this may help