### PR TITLE
fix: default to latest Tailwind CSS v3.x

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,10 @@
 Tailwind CSS for Symfony!
 =========================
 
+.. caution::
+
+    This bundle does not yet support Tailwind CSS 4.0.
+
 This bundle makes it easy to use `Tailwind CSS <https://tailwindcss.com/>`_ with
 Symfony's `AssetMapper Component <https://symfony.com/doc/current/frontend/asset_mapper.html>`_
 (no Node.js required!).

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -70,7 +70,7 @@ class TailwindExtension extends Extension implements ConfigurationInterface
                 ->end()
                 ->scalarNode('binary_version')
                     ->info('Tailwind CLI version to download - null means the latest version')
-                    ->defaultNull()
+                    ->defaultValue('v3.4.17')
                 ->end()
                 ->scalarNode('postcss_config_file')
                     ->info('Path to PostCSS config file which is passed to the Tailwind CLI')

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -94,7 +94,7 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
-            null,
+            'v3.4.17',
             __DIR__.'/fixtures/tailwind.config.js'
         );
         $process = $builder->runBuild(watch: false, poll: false, minify: true, inputFile: 'assets/styles/second.css');
@@ -115,7 +115,7 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
-            null,
+            'v3.4.17',
             __DIR__.'/fixtures/tailwind.config.js',
             __DIR__.'/fixtures/postcss.config.js',
         );


### PR DESCRIPTION
Tailwind CSS 4.0 is not supported out of the box with this bundle yet. See #81.

This sets the default version to 3.4.17 (the latest on the 3.x branch). This is temporary until 4.0 is supported.

Fixes #82.