### PR TITLE
Proposal to fix Tailwind CSS v4 support

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,11 @@
 Tailwind CSS for Symfony!
 =========================
 
+.. caution::
+
+    This bundle support Tailwind CSS 4.0 but PostCSS is not supported by the standalone binary.
+    Please specify a lower Tailwind binary version if you want to use PostCSS.
+
 This bundle makes it easy to use `Tailwind CSS <https://tailwindcss.com/>`_ with
 Symfony's `AssetMapper Component <https://symfony.com/doc/current/frontend/asset_mapper.html>`_
 (no Node.js required!).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -247,6 +247,11 @@ set ``binary_version`` option:
 Using a PostCSS config file
 ------------------------
 
+.. warning::
+
+    Tailwind CSS standalone binary v4.0.0 or higher doesn't support PostCSS anymore.
+    If you want to use PostCSS, please specify a previous binary version.
+
 If you want to use additional PostCSS plugins, you can specify the
 PostCSS config file to use, set ``postcss_config_file`` option or
 pass the ``--postcss`` option to the ``tailwind:build`` command.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,10 +1,6 @@
 Tailwind CSS for Symfony!
 =========================
 
-.. caution::
-
-    This bundle does not yet support Tailwind CSS 4.0.
-
 This bundle makes it easy to use `Tailwind CSS <https://tailwindcss.com/>`_ with
 Symfony's `AssetMapper Component <https://symfony.com/doc/current/frontend/asset_mapper.html>`_
 (no Node.js required!).

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@ Tailwind CSS for Symfony!
 .. caution::
 
     This bundle support Tailwind CSS 4.0 but PostCSS is not supported by the standalone binary.
-    Please specify a lower Tailwind binary version if you want to use PostCSS.
+    By default, the Tailwind CSS binary v3.4.17 is used and works with PostCSS.
 
 This bundle makes it easy to use `Tailwind CSS <https://tailwindcss.com/>`_ with
 Symfony's `AssetMapper Component <https://symfony.com/doc/current/frontend/asset_mapper.html>`_
@@ -250,7 +250,7 @@ Using a PostCSS config file
 .. warning::
 
     Tailwind CSS standalone binary v4.0.0 or higher doesn't support PostCSS anymore.
-    If you want to use PostCSS, please specify a previous binary version.
+    If you want to use PostCSS, let the default v3.4.17 binary version.
 
 If you want to use additional PostCSS plugins, you can specify the
 PostCSS config file to use, set ``postcss_config_file`` option or

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -94,13 +94,11 @@ class TailwindInitCommand extends Command
     {
         $inputFile = $this->tailwindBuilder->getInputCssPaths()[0];
         $contents = is_file($inputFile) ? file_get_contents($inputFile) : '';
-        $binaryVersion = $this->tailwindBuilder->getBinaryVersion();
-        $versionGreaterThan4 = strpos($binaryVersion, 'v') === 0 &&
-            version_compare(substr($binaryVersion, 1), '4') >= 0;
-        $tailwindGreaterThan4Directive = '@import "tailwindcss";';
+        $versionEqualsOrGreaterThan4 = $this->tailwindBuilder->isBinaryVersionEqualOrGreaterThan4();
+        $tailwindEqualsOrGreaterThan4Directive = '@import "tailwindcss";';
 
-        if ($versionGreaterThan4) {
-            if(str_contains($contents, $tailwindGreaterThan4Directive)) {
+        if ($versionEqualsOrGreaterThan4) {
+            if(str_contains($contents, $tailwindEqualsOrGreaterThan4Directive)) {
                 $io->note(sprintf('New Tailwind 4 or higher directive already exist in "%s"', $inputFile));
 
                 return;
@@ -111,18 +109,16 @@ class TailwindInitCommand extends Command
                 $contents = str_replace($oldDirectives, '', $contents);
             }
             $io->note(sprintf('Adding Tailwind 4 or higher directive to "%s"', $inputFile));
-            file_put_contents($inputFile, $tailwindGreaterThan4Directive.PHP_EOL.PHP_EOL.$contents);
-
-            return;
+            file_put_contents($inputFile, $tailwindEqualsOrGreaterThan4Directive.PHP_EOL.PHP_EOL.$contents);
         } else {
             if (str_contains($contents, '@tailwind base')) {
                 $io->note(\sprintf('Tailwind directives already exist in "%s"', $inputFile));
 
                 return;
             }
-            if (str_contains($contents, $tailwindGreaterThan4Directive)) {
+            if (str_contains($contents, $tailwindEqualsOrGreaterThan4Directive)) {
                 $io->note(sprintf('Removing Tailwind 4 or higher directive from "%s"', $inputFile));
-                $contents = str_replace($tailwindGreaterThan4Directive.PHP_EOL.PHP_EOL, '', $contents);
+                $contents = str_replace($tailwindEqualsOrGreaterThan4Directive.PHP_EOL.PHP_EOL, '', $contents);
             }
             $io->note(\sprintf('Adding Tailwind directives to "%s"', $inputFile));
             $tailwindDirectives = <<<EOF

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -98,18 +98,18 @@ class TailwindInitCommand extends Command
         $tailwindEqualsOrGreaterThan4Directive = '@import "tailwindcss";';
 
         if ($versionEqualsOrGreaterThan4) {
-            if(str_contains($contents, $tailwindEqualsOrGreaterThan4Directive)) {
-                $io->note(sprintf('New Tailwind 4 or higher directive already exist in "%s"', $inputFile));
+            if (str_contains($contents, $tailwindEqualsOrGreaterThan4Directive)) {
+                $io->note(\sprintf('New Tailwind 4 or higher directive already exist in "%s"', $inputFile));
 
                 return;
             }
             if (str_contains($contents, '@tailwind base')) {
-                $io->note(sprintf('Removing old Tailwind directives from "%s"', $inputFile));
-                $oldDirectives = '@tailwind base;'.PHP_EOL.'@tailwind components;'.PHP_EOL.'@tailwind utilities;'.PHP_EOL.PHP_EOL;
+                $io->note(\sprintf('Removing old Tailwind directives from "%s"', $inputFile));
+                $oldDirectives = '@tailwind base;'.\PHP_EOL.'@tailwind components;'.\PHP_EOL.'@tailwind utilities;'.\PHP_EOL.\PHP_EOL;
                 $contents = str_replace($oldDirectives, '', $contents);
             }
-            $io->note(sprintf('Adding Tailwind 4 or higher directive to "%s"', $inputFile));
-            file_put_contents($inputFile, $tailwindEqualsOrGreaterThan4Directive.PHP_EOL.PHP_EOL.$contents);
+            $io->note(\sprintf('Adding Tailwind 4 or higher directive to "%s"', $inputFile));
+            file_put_contents($inputFile, $tailwindEqualsOrGreaterThan4Directive.\PHP_EOL.\PHP_EOL.$contents);
         } else {
             if (str_contains($contents, '@tailwind base')) {
                 $io->note(\sprintf('Tailwind directives already exist in "%s"', $inputFile));
@@ -117,8 +117,8 @@ class TailwindInitCommand extends Command
                 return;
             }
             if (str_contains($contents, $tailwindEqualsOrGreaterThan4Directive)) {
-                $io->note(sprintf('Removing Tailwind 4 or higher directive from "%s"', $inputFile));
-                $contents = str_replace($tailwindEqualsOrGreaterThan4Directive.PHP_EOL.PHP_EOL, '', $contents);
+                $io->note(\sprintf('Removing Tailwind 4 or higher directive from "%s"', $inputFile));
+                $contents = str_replace($tailwindEqualsOrGreaterThan4Directive.\PHP_EOL.\PHP_EOL, '', $contents);
             }
             $io->note(\sprintf('Adding Tailwind directives to "%s"', $inputFile));
             $tailwindDirectives = <<<EOF
@@ -127,7 +127,7 @@ class TailwindInitCommand extends Command
             @tailwind utilities;
             EOF;
 
-            file_put_contents($inputFile, $tailwindDirectives.PHP_EOL.$contents);
+            file_put_contents($inputFile, $tailwindDirectives.\PHP_EOL.$contents);
         }
     }
 }

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -70,7 +70,7 @@ class TailwindExtension extends Extension implements ConfigurationInterface
                 ->end()
                 ->scalarNode('binary_version')
                     ->info('Tailwind CLI version to download - null means the latest version')
-                    ->defaultValue('v3.4.17')
+                    ->defaultNull()
                 ->end()
                 ->scalarNode('postcss_config_file')
                     ->info('Path to PostCSS config file which is passed to the Tailwind CLI')

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -70,7 +70,7 @@ class TailwindExtension extends Extension implements ConfigurationInterface
                 ->end()
                 ->scalarNode('binary_version')
                     ->info('Tailwind CLI version to download - null means the latest version')
-                    ->defaultNull()
+                    ->defaultValue('v3.4.17')
                 ->end()
                 ->scalarNode('postcss_config_file')
                     ->info('Path to PostCSS config file which is passed to the Tailwind CLI')

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Exception;
+
+/**
+ * Base ExceptionInterface for the TailwindCSS Bundle.
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Exception;
+
+/**
+ * Base InvalidArgumentException for the TailwindCSS Bundle.
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/TailwindBinary.php
+++ b/src/TailwindBinary.php
@@ -93,7 +93,7 @@ class TailwindBinary
         chmod($targetPath, 0777);
     }
 
-    private function getVersion(): string
+    public function getVersion(): string
     {
         return $this->cachedVersion ??= $this->binaryVersion ?? $this->getLatestVersion();
     }

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -140,6 +140,10 @@ class TailwindBuilder
         return file_get_contents($this->getInternalOutputCssPath($inputFile));
     }
 
+    public function getBinaryVersion(): string {
+        return $this->createBinary()->getVersion();
+    }
+
     private function validateInputFile(string $inputPath): string
     {
         if (is_file($inputPath)) {

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -140,8 +140,11 @@ class TailwindBuilder
         return file_get_contents($this->getInternalOutputCssPath($inputFile));
     }
 
-    public function getBinaryVersion(): string {
-        return $this->createBinary()->getVersion();
+    public function isBinaryVersionEqualOrGreaterThan4(): bool
+    {
+        $binaryVersion = $this->createBinary()->getVersion();
+        return str_starts_with($binaryVersion, 'v') &&
+            version_compare(substr($binaryVersion, 1), '4') >= 0;
     }
 
     private function validateInputFile(string $inputPath): string

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -143,8 +143,9 @@ class TailwindBuilder
     public function isBinaryVersionEqualOrGreaterThan4(): bool
     {
         $binaryVersion = $this->createBinary()->getVersion();
-        return str_starts_with($binaryVersion, 'v') &&
-            version_compare(substr($binaryVersion, 1), '4') >= 0;
+
+        return str_starts_with($binaryVersion, 'v')
+            && version_compare(substr($binaryVersion, 1), '4') >= 0;
     }
 
     private function validateInputFile(string $inputPath): string

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -32,7 +32,7 @@ class TailwindBuilderTest extends TestCase
         // so try to clean up the dir a few times
         while (true) {
             try {
-//                $fs->remove(__DIR__.'/fixtures/var/tailwind');
+                $fs->remove(__DIR__.'/fixtures/var/tailwind');
                 break;
             } catch (IOException $e) {
                 if ($i++ > 5) {

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -17,7 +17,6 @@ use Symfonycasts\TailwindBundle\TailwindBuilder;
 
 class TailwindBuilderTest extends TestCase
 {
-
     protected function setUp(): void
     {
         $fs = new Filesystem();
@@ -53,6 +52,7 @@ class TailwindBuilderTest extends TestCase
             '',
             new ArrayAdapter(),
         );
+
         return $versionBuilder->isBinaryVersionEqualOrGreaterThan4();
     }
 

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -94,7 +94,7 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
-            'v3.4.17',
+            null,
             __DIR__.'/fixtures/tailwind.config.js'
         );
         $process = $builder->runBuild(watch: false, poll: false, minify: true, inputFile: 'assets/styles/second.css');
@@ -115,7 +115,7 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures/var/tailwind',
             new ArrayAdapter(),
             null,
-            'v3.4.17',
+            null,
             __DIR__.'/fixtures/tailwind.config.js',
             __DIR__.'/fixtures/postcss.config.js',
         );

--- a/tests/fixtures/assets/styles/app-v4.css
+++ b/tests/fixtures/assets/styles/app-v4.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+body {
+    background-color: #ef4444;
+}

--- a/tests/fixtures/assets/styles/app.css
+++ b/tests/fixtures/assets/styles/app.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-    background-color: red;
+    background-color: #ef4444;
 }

--- a/tests/fixtures/assets/styles/second-v4.css
+++ b/tests/fixtures/assets/styles/second-v4.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+body {
+    background-color: #3b82f6;
+}

--- a/tests/fixtures/assets/styles/second.css
+++ b/tests/fixtures/assets/styles/second.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-    background-color: blue;
+    background-color: #3b82f6;
 }


### PR DESCRIPTION
Hi,
I faced the Tailwind CSS v4 issue with the bundle and noticed the last #83.
Here is a proposal to fix it and allow v4 support.

It just put the [new Tailwind CSS directive](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives) if the version used is equal or higher to v4, replace old directives if exist.