### PR TITLE
Don't download a new binary if one is already present.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -240,7 +240,7 @@ version it can find in your ``./var/tailwind`` directory will be used. In order 
 update to a new version, delete your ``./var/tailwind`` directory before running
 ``tailwind:build``.
 
-If instead you want to use only a specific version of tailwind, you can set the
+If instead, you want to use only a specific version of Tailwind, you can set the
 ``binary_version`` option:
 
 .. code-block:: yaml

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -234,7 +234,7 @@ Using a Different Binary Version
 ------------------------
 
 By default, when you run ``php bin/console tailwind:build``, the bundle will check
-to see if it's already downloaded a version of tailwind. If it hasn't, the
+to see if it's already downloaded a version of Tailwind binary. If it hasn't, the
 latest standalone Tailwind binary will be downloaded. If it has, the latest
 version it can find in your ``./var/tailwind`` directory will be used. In order to
 update to a new version, delete your ``./var/tailwind`` directory before running

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -233,15 +233,24 @@ To instruct the bundle to use that binary instead, set the ``binary`` option:
 Using a Different Binary Version
 ------------------------
 
-By default, the latest standalone Tailwind binary gets downloaded. However,
-if you want to use a different version, you can specify the version to use,
-set ``binary_version`` option:
+By default, when you run ``php bin/console tailwind:build``, the bundle will check
+to see if it's already downloaded a version of tailwind. If it hasn't, the
+latest standalone Tailwind binary will be downloaded. If it has, the latest
+version it can find in your ``./var/tailwind`` directory will be used. In order to
+update to a new version, delete your ``./var/tailwind`` directory before running
+``tailwind:build``.
+
+If instead you want to use only a specific version of tailwind, you can set the
+``binary_version`` option:
 
 .. code-block:: yaml
 
     # config/packages/symfonycasts_tailwind.yaml
     symfonycasts_tailwind:
         binary_version: 'v3.3.0'
+
+This will ignore any other versions you have installed, and only use the
+specified version.
 
 Using a PostCSS config file
 ------------------------

--- a/src/TailwindBinary.php
+++ b/src/TailwindBinary.php
@@ -95,7 +95,23 @@ class TailwindBinary
 
     private function getVersion(): string
     {
-        return $this->cachedVersion ??= $this->binaryVersion ?? $this->getLatestVersion();
+        return $this->cachedVersion ??= $this->binaryVersion
+            ?? $this->getLatestInstalledVersion()
+            ?? $this->getLatestVersion();
+    }
+
+    private function getLatestInstalledVersion(): ?string
+    {
+        $binaryName = self::getBinaryName();
+
+        $installedBinaries = glob("{$this->binaryDownloadDir}/v*/{$binaryName}");
+
+        $installedVersions = array_map(function (string $path) {
+            return basename(\dirname($path));
+        }, $installedBinaries);
+        usort($installedVersions, 'version_compare');
+
+        return end($installedVersions) ?: null;
     }
 
     private function getLatestVersion(): string


### PR DESCRIPTION
As discussed in #84, if a user has not configured a binary version, but has already downloaded an outdated tailwind binary, the outdated version will be used instead of downloading a new version.

This prevents builds from breaking when users unexpectedly are upgraded from v3.x to v4.

I could add a message that warns users they are not using the most up-to-date version, if necessary.