### PR TITLE
Tailwind v4 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/console": "^5.4|^6.3|^7.0",
         "symfony/http-client": "^5.4|^6.3|^7.0",
         "symfony/process": "^5.4|^6.3|^7.0",
-        "symfony/cache": "^6.3|^7.0"
+        "symfony/cache": "^6.3|^7.0",
+        "symfony/deprecation-contracts": "^2.2|^3.0"
     },
     "require-dev": {
         "symfony/filesystem": "^6.3|^7.0",

--- a/config/services.php
+++ b/config/services.php
@@ -12,16 +12,11 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
-        ->set('cache.symfonycasts.tailwind_bundle')
-            ->parent('cache.system')
-            ->tag('cache.pool')
-
         ->set('tailwind.builder', TailwindBuilder::class)
             ->args([
                 param('kernel.project_dir'),
                 abstract_arg('path to source Tailwind CSS file'),
                 param('kernel.project_dir').'/var/tailwind',
-                service('cache.symfonycasts.tailwind_bundle'),
                 abstract_arg('path to tailwind binary'),
                 abstract_arg('Tailwind binary version'),
                 abstract_arg('path to Tailwind CSS config file'),

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,10 +1,6 @@
 Tailwind CSS for Symfony!
 =========================
 
-.. caution::
-
-    This bundle does not yet support Tailwind CSS 4.0.
-
 This bundle makes it easy to use `Tailwind CSS <https://tailwindcss.com/>`_ with
 Symfony's `AssetMapper Component <https://symfony.com/doc/current/frontend/asset_mapper.html>`_
 (no Node.js required!).
@@ -30,6 +26,10 @@ Install the bundle & initialize your app with two commands:
 
 Done! This will create a ``tailwind.config.js`` file and make sure your
 ``assets/styles/app.css`` contains the Tailwind directives.
+
+.. note::
+
+    If using Tailwind CSS v4+, ``tailwind.config.js`` is not created or used.
 
 Usage
 -----
@@ -68,6 +68,10 @@ command with ``--poll`` option.
 .. code-block:: terminal
 
     $ php bin/console tailwind:build --watch --poll
+
+.. caution::
+
+    The ``--poll`` option is not available in Tailwind CSS v4+.
 
 Symfony CLI
 ~~~~~~~~~~~
@@ -130,6 +134,11 @@ The Tailwind binary that the bundle downloads already contains the "Official Plu
 This means you can use those simply by adding the line to the ``plugins`` key in
 ``tailwind.config.js`` - e.g. ``require('@tailwindcss/typography')``.
 
+.. note
+
+    In Tailwind CSS v4 you include plugins with the ``@plugin`` directive in your
+    input CSS file - e.g. ``@plugin "@tailwindcss/typography";``.
+
 For other plugins - like `Flowbite Datepicker <https://flowbite.com/docs/plugins/datepicker/>`_,
 you will need to follow that package's documentation to `require the package <https://flowbite.com/docs/getting-started/quickstart/#require-via-npm>`_
 with ``npm``:
@@ -178,6 +187,10 @@ It's possible to use multiple input files by providing an array:
 
 Another option is the ``config_file`` option, which defaults to ``tailwind.config.js``.
 This represents the Tailwind configuration file:
+
+.. caution::
+
+    The ``config_file`` is ignored in Tailwind CSS v4+.
 
 .. code-block:: yaml
 
@@ -231,11 +244,9 @@ To instruct the bundle to use that binary instead, set the ``binary`` option:
         binary: 'node_modules/.bin/tailwindcss'
 
 Using a Different Binary Version
-------------------------
+--------------------------------
 
-By default, the latest standalone Tailwind binary gets downloaded. However,
-if you want to use a different version, you can specify the version to use,
-set ``binary_version`` option:
+To use a different version, adjust the ``binary_version`` option:
 
 .. code-block:: yaml
 
@@ -244,7 +255,11 @@ set ``binary_version`` option:
         binary_version: 'v3.3.0'
 
 Using a PostCSS config file
-------------------------
+---------------------------
+
+.. caution::
+
+    PostCSS config is not available in Tailwind CSS v4+.
 
 If you want to use additional PostCSS plugins, you can specify the
 PostCSS config file to use, set ``postcss_config_file`` option or

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -48,6 +48,12 @@ class TailwindInitCommand extends Command
 
     private function createTailwindConfig(SymfonyStyle $io): bool
     {
+        if ($this->tailwindBuilder->createBinary()->isV4()) {
+            $io->note('Tailwind v4 detected: skipping config file creation.');
+
+            return true;
+        }
+
         $configFile = $this->tailwindBuilder->getConfigFilePath();
         if (file_exists($configFile)) {
             $io->note(\sprintf('Tailwind config file already exists in "%s"', $configFile));
@@ -94,7 +100,7 @@ class TailwindInitCommand extends Command
     {
         $inputFile = $this->tailwindBuilder->getInputCssPaths()[0];
         $contents = is_file($inputFile) ? file_get_contents($inputFile) : '';
-        if (str_contains($contents, '@tailwind base')) {
+        if (str_contains($contents, '@tailwind base') || str_contains($contents, '@import "tailwindcss"')) {
             $io->note(\sprintf('Tailwind directives already exist in "%s"', $inputFile));
 
             return;
@@ -106,6 +112,12 @@ class TailwindInitCommand extends Command
         @tailwind components;
         @tailwind utilities;
         EOF;
+
+        if ($this->tailwindBuilder->createBinary()->isV4()) {
+            $tailwindDirectives = <<<EOF
+            @import "tailwindcss";
+            EOF;
+        }
 
         file_put_contents($inputFile, $tailwindDirectives."\n\n".$contents);
     }

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -29,10 +29,10 @@ class TailwindExtension extends Extension implements ConfigurationInterface
 
         $container->findDefinition('tailwind.builder')
             ->replaceArgument(1, $config['input_css'])
-            ->replaceArgument(4, $config['binary'])
-            ->replaceArgument(5, $config['binary_version'])
-            ->replaceArgument(6, $config['config_file'])
-            ->replaceArgument(7, $config['postcss_config_file'])
+            ->replaceArgument(3, $config['binary'])
+            ->replaceArgument(4, $config['binary_version'])
+            ->replaceArgument(5, $config['config_file'])
+            ->replaceArgument(6, $config['postcss_config_file'])
         ;
     }
 
@@ -70,7 +70,13 @@ class TailwindExtension extends Extension implements ConfigurationInterface
                 ->end()
                 ->scalarNode('binary_version')
                     ->info('Tailwind CLI version to download - null means the latest version')
-                    ->defaultValue('v3.4.17')
+                    ->defaultNull()
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(static function (string $version): string {
+                            return 'v'.ltrim($version, 'vV');
+                        })
+                    ->end()
                 ->end()
                 ->scalarNode('postcss_config_file')
                     ->info('Path to PostCSS config file which is passed to the Tailwind CLI')

--- a/tests/TailwindBinaryTest.php
+++ b/tests/TailwindBinaryTest.php
@@ -14,7 +14,6 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Process\Process;
-use Symfony\Contracts\Cache\CacheInterface;
 use Symfonycasts\TailwindBundle\TailwindBinary;
 
 class TailwindBinaryTest extends TestCase
@@ -31,9 +30,8 @@ class TailwindBinaryTest extends TestCase
         $client = new MockHttpClient([
             new MockResponse('fake binary contents'),
         ]);
-        $cache = $this->createMock(CacheInterface::class);
 
-        $binary = new TailwindBinary($binaryDownloadDir, __DIR__, null, 'fake-version', $cache, null, $client);
+        $binary = new TailwindBinary($binaryDownloadDir, __DIR__, null, 'fake-version', null, $client);
         $process = $binary->createProcess(['-i', 'fake.css']);
         $binaryFile = $binaryDownloadDir.'/fake-version/'.TailwindBinary::getBinaryName();
         $this->assertFileExists($binaryFile);
@@ -44,12 +42,42 @@ class TailwindBinaryTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testGetVersionFromBinary(string $version)
+    {
+        $binaryDownloadDir = __DIR__.'/fixtures/download';
+        $fs = new Filesystem();
+        if (file_exists($binaryDownloadDir)) {
+            $fs->remove($binaryDownloadDir);
+        }
+        $fs->mkdir($binaryDownloadDir);
+        $binaryFile = $binaryDownloadDir.'/'.$version.'/'.TailwindBinary::getBinaryName();
+
+        $binary1 = new TailwindBinary($binaryDownloadDir, __DIR__, null, $version);
+
+        $binary1->createProcess();
+        $this->assertFileExists($binaryFile);
+        $this->assertSame($version, $binary1->getVersion());
+
+        // add both the binary path and invalid version to ensure version isn't used
+        $binary2 = new TailwindBinary($binaryDownloadDir, __DIR__, $binaryFile, 'v2.2.2');
+
+        $this->assertSame($version, $binary2->getVersion());
+    }
+
+    public static function versionProvider(): iterable
+    {
+        yield ['v3.4.17'];
+        yield ['v4.0.7'];
+    }
+
     public function testCustomBinaryUsed()
     {
         $client = new MockHttpClient();
-        $cache = $this->createMock(CacheInterface::class);
 
-        $binary = new TailwindBinary('', __DIR__, 'custom-binary', null, $cache, null, $client);
+        $binary = new TailwindBinary('', __DIR__, 'custom-binary', null, null, $client);
         $process = $binary->createProcess(['-i', 'fake.css']);
         // on windows, arguments are not wrapped in quotes
         $expected = '\\' === \DIRECTORY_SEPARATOR ? 'custom-binary -i fake.css' : "'custom-binary' '-i' 'fake.css'";

--- a/tests/TailwindBuilderTest.php
+++ b/tests/TailwindBuilderTest.php
@@ -10,7 +10,6 @@
 namespace Symfonycasts\TailwindBundle\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
@@ -44,13 +43,15 @@ class TailwindBuilderTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testIntegrationWithDefaultOptions(): void
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
             [__DIR__.'/fixtures/assets/styles/app.css'],
             __DIR__.'/fixtures/var/tailwind',
-            new ArrayAdapter(),
             null,
             null,
             __DIR__.'/fixtures/tailwind.config.js'
@@ -65,15 +66,33 @@ class TailwindBuilderTest extends TestCase
         $this->assertStringContainsString("body {\n  background-color: red;\n}", $outputFileContents, 'The output file should contain non-minified CSS.');
     }
 
+    public function testIntegrationWithV4(): void
+    {
+        $builder = new TailwindBuilder(
+            __DIR__.'/fixtures',
+            [__DIR__.'/fixtures/assets/styles/v4.css'],
+            __DIR__.'/fixtures/var/tailwind',
+            null,
+            'v4.0.7',
+        );
+        $process = $builder->runBuild(watch: false, poll: false, minify: false);
+        $process->wait();
+
+        $this->assertTrue($process->isSuccessful());
+        $this->assertFileExists(__DIR__.'/fixtures/var/tailwind/v4.built.css');
+
+        $outputFileContents = file_get_contents(__DIR__.'/fixtures/var/tailwind/v4.built.css');
+        $this->assertStringContainsString("body {\n  background-color: black;\n}", $outputFileContents, 'The output file should contain non-minified CSS.');
+    }
+
     public function testIntegrationWithMinify(): void
     {
         $builder = new TailwindBuilder(
             __DIR__.'/fixtures',
             [__DIR__.'/fixtures/assets/styles/app.css'],
             __DIR__.'/fixtures/var/tailwind',
-            new ArrayAdapter(),
             null,
-            null,
+            'v3.4.17',
             __DIR__.'/fixtures/tailwind.config.js'
         );
         $process = $builder->runBuild(watch: false, poll: false, minify: true);
@@ -92,7 +111,6 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures',
             [__DIR__.'/fixtures/assets/styles/app.css', __DIR__.'/fixtures/assets/styles/second.css'],
             __DIR__.'/fixtures/var/tailwind',
-            new ArrayAdapter(),
             null,
             'v3.4.17',
             __DIR__.'/fixtures/tailwind.config.js'
@@ -113,7 +131,6 @@ class TailwindBuilderTest extends TestCase
             __DIR__.'/fixtures',
             [__DIR__.'/fixtures/assets/styles/app.css'],
             __DIR__.'/fixtures/var/tailwind',
-            new ArrayAdapter(),
             null,
             'v3.4.17',
             __DIR__.'/fixtures/tailwind.config.js',

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -52,6 +52,7 @@ class TailwindTestKernel extends Kernel
 
         $container->loadFromExtension('symfonycasts_tailwind', [
             'input_css' => [__DIR__.'/assets/styles/app.css'],
+            'binary_version' => 'v3.4.17',
         ]);
     }
 

--- a/tests/fixtures/assets/styles/v4.css
+++ b/tests/fixtures/assets/styles/v4.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+body {
+    background-color: black;
+}


### PR DESCRIPTION
- [x] require `binary` or `binary_version` be configured
- [x] normalize `binary_version` (1.2.3 => v1.2.3)
- [x] determine version from binary
- [x] `tailwind:build` v4 compatible
- [x] `tailwind:init` v4 compatible
- [x] docs
- [x] [Investigate the different binaries made available in v4+](https://github.com/SymfonyCasts/tailwind-bundle/pull/91#issuecomment-2698000585)
- [x] Recipe with pre-set version: https://github.com/symfony/recipes/pull/1383

Closes #86
Closes #87
Fixes #84
Fixes #81