### PR TITLE
Add *strict mode*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/var/
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache

--- a/config/services.php
+++ b/config/services.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container): void {
         ->set('tailwind.css_asset_compiler', TailwindCssAssetCompiler::class)
             ->args([
                 service('tailwind.builder'),
+                abstract_arg('strict mode'),
             ])
             ->tag('asset_mapper.compiler', [
                 // run before core CssAssetUrlCompiler that resolves url() references

--- a/src/AssetMapper/TailwindCssAssetCompiler.php
+++ b/src/AssetMapper/TailwindCssAssetCompiler.php
@@ -19,16 +19,21 @@ use Symfonycasts\TailwindBundle\TailwindBuilder;
  */
 class TailwindCssAssetCompiler implements AssetCompilerInterface
 {
-    public function __construct(private TailwindBuilder $tailwindBuilder)
+    public function __construct(private TailwindBuilder $tailwindBuilder, private bool $strictMode = true)
     {
     }
 
     public function supports(MappedAsset $asset): bool
     {
-        return \in_array(
-            realpath($asset->sourcePath),
-            $this->tailwindBuilder->getInputCssPaths(),
-        );
+        if (!\in_array(realpath($asset->sourcePath), $this->tailwindBuilder->getInputCssPaths())) {
+            return false;
+        }
+
+        if (!$this->strictMode && !file_exists($this->tailwindBuilder->getInternalOutputCssPath($asset->sourcePath))) {
+            return false;
+        }
+
+        return true;
     }
 
     public function compile(string $content, MappedAsset $asset, AssetMapperInterface $assetMapper): string

--- a/src/DependencyInjection/TailwindExtension.php
+++ b/src/DependencyInjection/TailwindExtension.php
@@ -27,6 +27,12 @@ class TailwindExtension extends Extension implements ConfigurationInterface
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $strictMode = $config['strict_mode'] ?? ('test' !== $container->getParameter('kernel.environment'));
+
+        $container->findDefinition('tailwind.css_asset_compiler')
+            ->replaceArgument(1, $strictMode)
+        ;
+
         $container->findDefinition('tailwind.builder')
             ->replaceArgument(1, $config['input_css'])
             ->replaceArgument(3, $config['binary'])
@@ -80,6 +86,10 @@ class TailwindExtension extends Extension implements ConfigurationInterface
                 ->end()
                 ->scalarNode('postcss_config_file')
                     ->info('Path to PostCSS config file which is passed to the Tailwind CLI')
+                    ->defaultNull()
+                ->end()
+                ->booleanNode('strict_mode')
+                    ->info('When enabled, an exception will be thrown if there are no built assets (default: false in `test` env, true otherwise)')
                     ->defaultNull()
                 ->end()
             ->end();

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -20,11 +20,6 @@ class TailwindTestKernel extends Kernel
 {
     use MicroKernelTrait;
 
-    public function __construct()
-    {
-        parent::__construct('test', true);
-    }
-
     public function registerBundles(): array
     {
         return [
@@ -54,20 +49,5 @@ class TailwindTestKernel extends Kernel
             'input_css' => [__DIR__.'/assets/styles/app.css'],
             'binary_version' => 'v3.4.17',
         ]);
-    }
-
-    public function getCacheDir(): string
-    {
-        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
-    }
-
-    public function getLogDir(): string
-    {
-        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
-    }
-
-    public function getProjectDir(): string
-    {
-        return __DIR__;
     }
 }


### PR DESCRIPTION
- When active, throw an exception if tailwind assets aren't built
- Default: `true` in all environments but `test`

Currently, kernel tests throw an exception if tailwind isn't built. In these tests, it isn't important.