### PR TITLE
Allow symfony 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,17 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/asset-mapper": "^6.3|^7.0",
-        "symfony/console": "^5.4|^6.3|^7.0",
-        "symfony/http-client": "^5.4|^6.3|^7.0",
-        "symfony/process": "^5.4|^6.3|^7.0",
-        "symfony/cache": "^6.3|^7.0",
+        "symfony/asset-mapper": "^6.3|^7.0|^8.0",
+        "symfony/console": "^5.4|^6.3|^7.0|^8.0",
+        "symfony/http-client": "^5.4|^6.3|^7.0|^8.0",
+        "symfony/process": "^5.4|^6.3|^7.0|^8.0",
+        "symfony/cache": "^6.3|^7.0|^8.0",
         "symfony/deprecation-contracts": "^2.2|^3.0"
     },
     "require-dev": {
-        "symfony/filesystem": "^6.3|^7.0",
-        "symfony/framework-bundle": "^6.3|^7.0",
-        "symfony/phpunit-bridge": "^6.3.9|^7.0",
+        "symfony/filesystem": "^6.3|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.3|^7.0|^8.0",
+        "symfony/phpunit-bridge": "^6.3.9|^7.0|^8.0",
         "phpunit/phpunit": "^9.6"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Hello

I allowed SF8 in composer.json

The `composer install` already took the latests dev version (on 8.1 branch), and tests still pass