### PR TITLE
Change CI cron schedule to weekly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
     push:
         branches: ['main']
     schedule:
-        - cron: '0 */12 * * *'
+        - cron: '0 0 * * 0'
 
 jobs:
     test:


### PR DESCRIPTION
Updated cron schedule to run weekly instead of every 12 hours.