### PR TITLE
Add `tailwind:update` command

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -4,6 +4,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfonycasts\TailwindBundle\AssetMapper\TailwindCssAssetCompiler;
 use Symfonycasts\TailwindBundle\Command\TailwindBuildCommand;
 use Symfonycasts\TailwindBundle\Command\TailwindInitCommand;
+use Symfonycasts\TailwindBundle\Command\TailwindUpdateCommand;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
 use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 
@@ -39,6 +40,15 @@ return static function (ContainerConfigurator $container): void {
                 service('tailwind.version_finder'),
                 abstract_arg('path to source Tailwind CSS file'),
                 param('kernel.project_dir'),
+            ])
+            ->tag('console.command')
+
+        ->set('tailwind.command.update', TailwindUpdateCommand::class)
+            ->args([
+                service('tailwind.version_finder'),
+                param('kernel.project_dir'),
+                abstract_arg('path to tailwind binary'),
+                abstract_arg('Tailwind binary version'),
             ])
             ->tag('console.command')
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -249,6 +249,36 @@ To use a different version, adjust the ``binary_version`` option:
     symfonycasts_tailwind:
         binary_version: 'v3.3.0'
 
+Updating Tailwind
+-----------------
+
+To update to the latest Tailwind CSS release *within your current major version*,
+run the ``tailwind:update`` command:
+
+.. code-block:: terminal
+
+    $ php bin/console tailwind:update
+
+This finds the latest release matching your current major version (e.g. if you're
+on ``v3.3.0`` it will look for the latest ``3.x`` release) and updates the
+``binary_version`` option in ``config/packages/symfonycasts_tailwind.yaml`` for you.
+The next time you run ``tailwind:build``, the new binary is downloaded automatically.
+
+.. note::
+
+    If a ``tailwind:build --watch`` process (or worker) is already running, restart
+    it after updating - it keeps using the binary it started with until then.
+
+.. note::
+
+    To move to a *new* major version (e.g. from ``3.x`` to ``4.x``), set the
+    ``binary_version`` option manually - see `Using a Different Binary Version`_.
+
+.. note::
+
+    If you're managing your own binary (the ``binary`` option is set), this
+    command can't update it for you - update it manually instead.
+
 Using a Different Binary Platform
 ---------------------------------
 

--- a/src/Command/TailwindConfigCommand.php
+++ b/src/Command/TailwindConfigCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Yaml\Yaml;
+
+abstract class TailwindConfigCommand extends Command
+{
+    public function __construct(
+        protected string $rootDir,
+    ) {
+        parent::__construct();
+    }
+
+    protected function bundleConfigFile(): string
+    {
+        return $this->rootDir.'/config/packages/symfonycasts_tailwind.yaml';
+    }
+
+    protected function bundleConfig(): array
+    {
+        if (!class_exists(Yaml::class)) {
+            throw new \RuntimeException('You are using a non-standard Symfony setup. You will need to manage the bundle configuration manually.');
+        }
+
+        if (!file_exists($this->bundleConfigFile())) {
+            return [];
+        }
+
+        return Yaml::parseFile($this->bundleConfigFile());
+    }
+
+    protected function writeBundleConfig(array $bundleConfig): void
+    {
+        file_put_contents($this->bundleConfigFile(), Yaml::dump($bundleConfig));
+    }
+}

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -10,11 +10,9 @@
 namespace Symfonycasts\TailwindBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Yaml\Yaml;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
 use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 
@@ -22,14 +20,14 @@ use Symfonycasts\TailwindBundle\TailwindVersionFinder;
     name: 'tailwind:init',
     description: 'Initializes Tailwind CSS for your project',
 )]
-class TailwindInitCommand extends Command
+class TailwindInitCommand extends TailwindConfigCommand
 {
     public function __construct(
         private TailwindVersionFinder $versionFinder,
         private array $inputCss,
-        private string $rootDir,
+        string $rootDir,
     ) {
-        parent::__construct();
+        parent::__construct($rootDir);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -51,7 +49,7 @@ class TailwindInitCommand extends Command
             $bundleConfig['symfonycasts_tailwind']['binary_version'] = $latestVersion;
         }
 
-        file_put_contents($this->bundleConfigFile(), Yaml::dump($bundleConfig));
+        $this->writeBundleConfig($bundleConfig);
 
         $builder = new TailwindBuilder(
             $this->rootDir,
@@ -146,23 +144,5 @@ class TailwindInitCommand extends Command
         }
 
         file_put_contents($inputFile, $tailwindDirectives."\n\n".$contents);
-    }
-
-    private function bundleConfigFile(): string
-    {
-        return $this->rootDir.'/config/packages/symfonycasts_tailwind.yaml';
-    }
-
-    private function bundleConfig(): array
-    {
-        if (!class_exists(Yaml::class)) {
-            throw new \RuntimeException('You are using a non-standard Symfony setup. You will need to initialize this bundle manually.');
-        }
-
-        if (!file_exists($this->bundleConfigFile())) {
-            return [];
-        }
-
-        return Yaml::parseFile($this->bundleConfigFile());
     }
 }

--- a/src/Command/TailwindUpdateCommand.php
+++ b/src/Command/TailwindUpdateCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfonycasts\TailwindBundle\TailwindVersionFinder;
+
+#[AsCommand(
+    name: 'tailwind:update',
+    description: 'Updates the Tailwind CSS binary to the latest version within the current major',
+)]
+class TailwindUpdateCommand extends TailwindConfigCommand
+{
+    public function __construct(
+        private TailwindVersionFinder $versionFinder,
+        string $rootDir,
+        private ?string $binaryPath,
+        private ?string $binaryVersion,
+    ) {
+        parent::__construct($rootDir);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($this->binaryPath) {
+            throw new \RuntimeException('Cannot update: you are managing your own Tailwind CSS binary. Update it manually.');
+        }
+
+        if (!$this->binaryVersion) {
+            throw new \RuntimeException('Cannot determine the current version. Set "binary_version" in your symfonycasts_tailwind config (or run "tailwind:init").');
+        }
+
+        $io->note(\sprintf('Current version: %s — looking for the latest release in the same major...', $this->binaryVersion));
+
+        $latestVersion = $this->versionFinder->latestVersionFor($this->binaryVersion);
+
+        if ($latestVersion === $this->binaryVersion) {
+            $io->success(\sprintf('Already on the latest version (%s). Nothing to do!', $latestVersion));
+
+            return self::SUCCESS;
+        }
+
+        $bundleConfig = $this->bundleConfig();
+
+        if (!$bundleConfig) {
+            throw new \RuntimeException('You are using a non-standard Symfony setup. Update "binary_version" in your config manually.');
+        }
+
+        $bundleConfig['symfonycasts_tailwind']['binary_version'] = $latestVersion;
+        $this->writeBundleConfig($bundleConfig);
+
+        $io->success(\sprintf('Tailwind CSS updated from %s to %s!', $this->binaryVersion, $latestVersion));
+        $io->note('If "tailwind:build --watch" is running, restart it to use the new version.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/SymfonycastsTailwindBundle.php
+++ b/src/SymfonycastsTailwindBundle.php
@@ -89,5 +89,10 @@ class SymfonycastsTailwindBundle extends AbstractBundle
         $builder->findDefinition('tailwind.command.init')
             ->replaceArgument(1, $config['input_css'])
         ;
+
+        $builder->findDefinition('tailwind.command.update')
+            ->replaceArgument(2, $config['binary'])
+            ->replaceArgument(3, $config['binary_version'])
+        ;
     }
 }

--- a/src/TailwindVersionFinder.php
+++ b/src/TailwindVersionFinder.php
@@ -26,8 +26,18 @@ final class TailwindVersionFinder
         $this->httpClient = $httpClient ?? HttpClient::create();
     }
 
-    public function latestVersionFor(int $majorVersion): string
+    /**
+     * Finds the latest release sharing the major version of the given
+     * version string (e.g. "4", "v4.2.0", "3.3" all resolve their major).
+     */
+    public function latestVersionFor(string $version): string
     {
+        if (!preg_match('/^v?(\d+)/', $version, $matches)) {
+            throw new \InvalidArgumentException(\sprintf('Cannot parse major version from "%s".', $version));
+        }
+
+        $majorVersion = (int) $matches[1];
+
         foreach ($this->tags() as $tag) {
             if (str_starts_with($tag, "v$majorVersion.")) {
                 return $tag;

--- a/tests/Command/BaseCommandTestCase.php
+++ b/tests/Command/BaseCommandTestCase.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Tests\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfonycasts\TailwindBundle\Tests\fixtures\TailwindTestKernel;
+
+abstract class BaseCommandTestCase extends KernelTestCase
+{
+    protected const FIXTURES_DIR = __DIR__.'/../fixtures';
+
+    protected Filesystem $filesystem;
+    protected string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->tempDir = sys_get_temp_dir().'/tailwind-bundle-test-'.uniqid();
+        $this->filesystem->mkdir($this->tempDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->tempDir);
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return new TailwindTestKernel(
+            $options['environment'] ?? 'test',
+            $options['debug'] ?? false,
+            $options['tailwind_config'] ?? [],
+            $options['project_dir'] ?? null,
+            $options['version_finder_releases'] ?? null,
+        );
+    }
+
+    protected function commandTester(string $name): CommandTester
+    {
+        $application = new Application(self::$kernel);
+
+        return new CommandTester($application->find($name));
+    }
+}

--- a/tests/Command/TailwindBuildCommandTest.php
+++ b/tests/Command/TailwindBuildCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Tests\Command;
+
+class TailwindBuildCommandTest extends BaseCommandTestCase
+{
+    public function testBuild(): void
+    {
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'tailwind_config' => [
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/v4.css'],
+                'binary_version' => 'v4.0.7',
+            ],
+        ]);
+
+        $builtCss = $this->tempDir.'/var/tailwind/v4.built.css';
+        $this->assertFileDoesNotExist($builtCss);
+
+        $tester = $this->commandTester('tailwind:build');
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertFileExists($builtCss);
+    }
+}

--- a/tests/Command/TailwindInitCommandTest.php
+++ b/tests/Command/TailwindInitCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Tests\Command;
+
+use Symfony\Component\Yaml\Yaml;
+
+class TailwindInitCommandTest extends BaseCommandTestCase
+{
+    public function testInit(): void
+    {
+        $cssFile = $this->tempDir.'/assets/styles/app.css';
+        $this->filesystem->dumpFile($cssFile, '/* existing styles */');
+        // config/packages always exists in a real Symfony app
+        $this->filesystem->mkdir($this->tempDir.'/config/packages');
+
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'version_finder_releases' => ['v4.1.0', 'v3.4.20', 'v3.4.17'],
+            'tailwind_config' => [
+                'input_css' => [$cssFile],
+                'binary_version' => 'v3.4.17',
+            ],
+        ]);
+
+        $configFile = $this->tempDir.'/config/packages/symfonycasts_tailwind.yaml';
+        $this->assertFileDoesNotExist($configFile);
+        $this->assertStringNotContainsString('@import "tailwindcss";', file_get_contents($cssFile));
+
+        $tester = $this->commandTester('tailwind:init');
+        // 1) not managing own binary, 2) major version 4 (v4 needs no binary to init)
+        $tester->setInputs(['no', '4']);
+        $tester->execute([], ['interactive' => true]);
+
+        $tester->assertCommandIsSuccessful();
+
+        $config = Yaml::parseFile($configFile);
+        $this->assertSame('v4.1.0', $config['symfonycasts_tailwind']['binary_version']);
+
+        $css = file_get_contents($cssFile);
+        $this->assertStringContainsString('@import "tailwindcss";', $css);
+        $this->assertStringContainsString('/* existing styles */', $css);
+    }
+
+    public function testMustBeRunInteractively(): void
+    {
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'tailwind_config' => [
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/app.css'],
+                'binary_version' => 'v3.4.17',
+            ],
+        ]);
+
+        $tester = $this->commandTester('tailwind:init');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('tailwind:init command must be run interactively');
+
+        $tester->execute([], ['interactive' => false]);
+    }
+}

--- a/tests/Command/TailwindUpdateCommandTest.php
+++ b/tests/Command/TailwindUpdateCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the SymfonyCasts TailwindBundle package.
+ * Copyright (c) SymfonyCasts <https://symfonycasts.com/>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfonycasts\TailwindBundle\Tests\Command;
+
+use Symfony\Component\Yaml\Yaml;
+
+class TailwindUpdateCommandTest extends BaseCommandTestCase
+{
+    public function testUpdate(): void
+    {
+        $configFile = $this->tempDir.'/config/packages/symfonycasts_tailwind.yaml';
+        $this->filesystem->dumpFile($configFile, Yaml::dump([
+            'symfonycasts_tailwind' => ['binary_version' => 'v3.4.17'],
+        ]));
+
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'version_finder_releases' => ['v4.1.0', 'v3.4.20', 'v3.4.17'],
+            'tailwind_config' => [
+                'binary_version' => 'v3.4.17',
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/app.css'],
+            ],
+        ]);
+
+        $this->assertSame('v3.4.17', Yaml::parseFile($configFile)['symfonycasts_tailwind']['binary_version']);
+
+        $tester = $this->commandTester('tailwind:update');
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('updated from v3.4.17 to v3.4.20', $tester->getDisplay());
+        $this->assertSame('v3.4.20', Yaml::parseFile($configFile)['symfonycasts_tailwind']['binary_version']);
+    }
+
+    public function testCannotUpdateWhenManagingOwnBinary(): void
+    {
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'tailwind_config' => [
+                'binary' => 'node_modules/.bin/tailwindcss',
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/app.css'],
+            ],
+        ]);
+
+        $tester = $this->commandTester('tailwind:update');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('you are managing your own Tailwind CSS binary');
+
+        $tester->execute([]);
+    }
+
+    public function testCannotUpdateWithoutCurrentVersion(): void
+    {
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'tailwind_config' => [
+                // no binary_version configured, so the current version is unknown
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/app.css'],
+            ],
+        ]);
+
+        $tester = $this->commandTester('tailwind:update');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot determine the current version');
+
+        $tester->execute([]);
+    }
+
+    public function testCannotUpdateWithoutABundleConfigFile(): void
+    {
+        // a newer release is available, but there is no config file to update
+        self::bootKernel([
+            'project_dir' => $this->tempDir,
+            'version_finder_releases' => ['v3.4.20', 'v3.4.17'],
+            'tailwind_config' => [
+                'binary_version' => 'v3.4.17',
+                'input_css' => [self::FIXTURES_DIR.'/assets/styles/app.css'],
+            ],
+        ]);
+
+        $tester = $this->commandTester('tailwind:update');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('non-standard Symfony setup');
+
+        $tester->execute([]);
+    }
+}

--- a/tests/TailwindVersionFinderTest.php
+++ b/tests/TailwindVersionFinderTest.php
@@ -16,9 +16,9 @@ use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 class TailwindVersionFinderTest extends TestCase
 {
     /**
-     * @dataProvider majorVersionProvider
+     * @dataProvider versionProvider
      */
-    public function testGetLatestVersion(int $majorVersion): void
+    public function testGetLatestVersion(string $version, int $expectedMajor): void
     {
         $options = [];
 
@@ -27,17 +27,26 @@ class TailwindVersionFinderTest extends TestCase
         }
 
         $versionDetector = new TailwindVersionFinder(HttpClient::create($options));
-        $latestVersion = $versionDetector->latestVersionFor($majorVersion);
+        $latestVersion = $versionDetector->latestVersionFor($version);
 
-        $this->assertStringStartsWith('v'.$majorVersion.'.', $latestVersion);
+        $this->assertStringStartsWith('v'.$expectedMajor.'.', $latestVersion);
     }
 
-    public static function majorVersionProvider(): array
+    public static function versionProvider(): array
     {
         return [
-            [2],
-            [3],
-            [4],
+            'major only' => ['2', 2],
+            'v-prefixed major' => ['v3', 3],
+            'full version' => ['v4.2.0', 4],
+            'partial version' => ['3.3', 3],
         ];
+    }
+
+    public function testThrowsOnUnparsableVersion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot parse major version from "nope".');
+
+        (new TailwindVersionFinder())->latestVersionFor('nope');
     }
 }

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -13,16 +13,42 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfonycasts\TailwindBundle\SymfonycastsTailwindBundle;
+use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 
 class TailwindTestKernel extends Kernel
 {
     use MicroKernelTrait;
 
-    public function __construct(string $environment, bool $debug, private readonly array $tailwindConfig = [])
-    {
+    /**
+     * @param string[]|null $versionFinderReleases tailwind release tags the mocked finder should return (newest first),
+     *                                             or null to use the real (network) finder
+     */
+    public function __construct(
+        string $environment,
+        bool $debug,
+        private readonly array $tailwindConfig = [],
+        private readonly ?string $projectDir = null,
+        private readonly ?array $versionFinderReleases = null,
+    ) {
         parent::__construct($environment, $debug);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir ?? parent::getProjectDir();
+    }
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        if (null !== $this->versionFinderReleases) {
+            $this->container->set('tailwind.version_finder', new TailwindVersionFinder($this->mockHttpClient()));
+        }
     }
 
     public function registerBundles(): array
@@ -54,5 +80,30 @@ class TailwindTestKernel extends Kernel
             'input_css' => [__DIR__.'/assets/styles/app.css'],
             'binary_version' => 'v3.4.17',
         ]);
+
+        if (null !== $this->versionFinderReleases) {
+            // declared synthetic so the real instance (with a mock client) can be set in boot()
+            $container->register('tailwind.version_finder', TailwindVersionFinder::class)
+                ->setSynthetic(true)
+                ->setPublic(true);
+        }
+    }
+
+    /**
+     * A client that mimics the GitHub releases API without hitting the network.
+     */
+    private function mockHttpClient(): MockHttpClient
+    {
+        $releases = array_map(static fn (string $tag) => ['tag_name' => $tag], $this->versionFinderReleases);
+
+        return new MockHttpClient(static function (string $method, string $url) use ($releases): MockResponse {
+            parse_str(parse_url($url, \PHP_URL_QUERY) ?: '', $query);
+
+            // first page lists the releases, later pages are empty to stop pagination
+            return new MockResponse(
+                json_encode('1' === ($query['page'] ?? '1') ? $releases : []),
+                ['response_headers' => ['Content-Type' => 'application/json']],
+            );
+        });
     }
 }


### PR DESCRIPTION
This pull request introduces a new `tailwind:update` command to simplify updating the Tailwind CSS binary to the latest release within the current major version. 

Closes #94 
