### PR TITLE
Lock down public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Symfony (and learn a bucket-load) by grabbing a subscription to [SymfonyCasts](h
 ## Credits
 
 - [Ryan Weaver](https://github.com/weaverryan)
+- [Kevin Bond](https://github.com/kbond)
 - [All Contributors](../../contributors)
 
 ## License

--- a/config/services.php
+++ b/config/services.php
@@ -14,7 +14,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
-        ->set('tailwind.builder', TailwindBuilder::class)
+        ->set('.tailwind.builder', TailwindBuilder::class)
             ->args([
                 param('kernel.project_dir'),
                 abstract_arg('path to source Tailwind CSS file'),
@@ -27,34 +27,34 @@ return static function (ContainerConfigurator $container): void {
                 abstract_arg('process timeout in seconds'),
             ])
 
-        ->set('tailwind.version_finder', TailwindVersionFinder::class)
+        ->set('.tailwind.version_finder', TailwindVersionFinder::class)
 
-        ->set('tailwind.command.build', TailwindBuildCommand::class)
+        ->set('.tailwind.command.build', TailwindBuildCommand::class)
             ->args([
-                service('tailwind.builder'),
+                service('.tailwind.builder'),
             ])
             ->tag('console.command')
 
-        ->set('tailwind.command.init', TailwindInitCommand::class)
+        ->set('.tailwind.command.init', TailwindInitCommand::class)
             ->args([
-                service('tailwind.version_finder'),
+                service('.tailwind.version_finder'),
                 abstract_arg('path to source Tailwind CSS file'),
                 param('kernel.project_dir'),
             ])
             ->tag('console.command')
 
-        ->set('tailwind.command.update', TailwindUpdateCommand::class)
+        ->set('.tailwind.command.update', TailwindUpdateCommand::class)
             ->args([
-                service('tailwind.version_finder'),
+                service('.tailwind.version_finder'),
                 param('kernel.project_dir'),
                 abstract_arg('path to tailwind binary'),
                 abstract_arg('Tailwind binary version'),
             ])
             ->tag('console.command')
 
-        ->set('tailwind.css_asset_compiler', TailwindCssAssetCompiler::class)
+        ->set('.tailwind.css_asset_compiler', TailwindCssAssetCompiler::class)
             ->args([
-                service('tailwind.builder'),
+                service('.tailwind.builder'),
                 abstract_arg('strict mode'),
             ])
             ->tag('asset_mapper.compiler', [

--- a/src/AssetMapper/TailwindCssAssetCompiler.php
+++ b/src/AssetMapper/TailwindCssAssetCompiler.php
@@ -16,8 +16,10 @@ use Symfonycasts\TailwindBundle\TailwindBuilder;
 
 /**
  * Intercepts the "input" Tailwind CSS file and changes its contents to the built version.
+ *
+ * @internal
  */
-class TailwindCssAssetCompiler implements AssetCompilerInterface
+final class TailwindCssAssetCompiler implements AssetCompilerInterface
 {
     public function __construct(private TailwindBuilder $tailwindBuilder, private bool $strictMode = true)
     {

--- a/src/Command/TailwindBuildCommand.php
+++ b/src/Command/TailwindBuildCommand.php
@@ -18,11 +18,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
 
+/**
+ * @internal
+ */
 #[AsCommand(
     name: 'tailwind:build',
     description: 'Builds the Tailwind CSS assets.',
 )]
-class TailwindBuildCommand extends Command
+final class TailwindBuildCommand extends Command
 {
     public function __construct(
         private TailwindBuilder $tailwindBuilder,

--- a/src/Command/TailwindConfigCommand.php
+++ b/src/Command/TailwindConfigCommand.php
@@ -12,6 +12,9 @@ namespace Symfonycasts\TailwindBundle\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @internal
+ */
 abstract class TailwindConfigCommand extends Command
 {
     public function __construct(

--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -16,11 +16,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
 use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 
+/**
+ * @internal
+ */
 #[AsCommand(
     name: 'tailwind:init',
     description: 'Initializes Tailwind CSS for your project',
 )]
-class TailwindInitCommand extends TailwindConfigCommand
+final class TailwindInitCommand extends TailwindConfigCommand
 {
     public function __construct(
         private TailwindVersionFinder $versionFinder,

--- a/src/Command/TailwindUpdateCommand.php
+++ b/src/Command/TailwindUpdateCommand.php
@@ -15,11 +15,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfonycasts\TailwindBundle\TailwindVersionFinder;
 
+/**
+ * @internal
+ */
 #[AsCommand(
     name: 'tailwind:update',
     description: 'Updates the Tailwind CSS binary to the latest version within the current major',
 )]
-class TailwindUpdateCommand extends TailwindConfigCommand
+final class TailwindUpdateCommand extends TailwindConfigCommand
 {
     public function __construct(
         private TailwindVersionFinder $versionFinder,

--- a/src/SymfonycastsTailwindBundle.php
+++ b/src/SymfonycastsTailwindBundle.php
@@ -72,11 +72,11 @@ class SymfonycastsTailwindBundle extends AbstractBundle
 
         $strictMode = $config['strict_mode'] ?? ('test' !== $builder->getParameter('kernel.environment'));
 
-        $builder->findDefinition('tailwind.css_asset_compiler')
+        $builder->findDefinition('.tailwind.css_asset_compiler')
             ->replaceArgument(1, $strictMode)
         ;
 
-        $builder->findDefinition('tailwind.builder')
+        $builder->findDefinition('.tailwind.builder')
             ->replaceArgument(1, $config['input_css'])
             ->replaceArgument(3, $config['binary'])
             ->replaceArgument(4, $config['binary_version'])
@@ -86,11 +86,11 @@ class SymfonycastsTailwindBundle extends AbstractBundle
             ->replaceArgument(8, $config['process_timeout'])
         ;
 
-        $builder->findDefinition('tailwind.command.init')
+        $builder->findDefinition('.tailwind.command.init')
             ->replaceArgument(1, $config['input_css'])
         ;
 
-        $builder->findDefinition('tailwind.command.update')
+        $builder->findDefinition('.tailwind.command.update')
             ->replaceArgument(2, $config['binary'])
             ->replaceArgument(3, $config['binary_version'])
         ;

--- a/src/TailwindBinary.php
+++ b/src/TailwindBinary.php
@@ -18,8 +18,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * Wraps and downloads the tailwindcss binary.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @internal
  */
-class TailwindBinary
+final class TailwindBinary
 {
     private const DEFAULT_VERSION = 'v3.4.17';
 

--- a/src/TailwindBuilder.php
+++ b/src/TailwindBuilder.php
@@ -18,9 +18,9 @@ use Symfony\Component\Process\Process;
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
  *
- * @final
+ * @internal
  */
-class TailwindBuilder
+final class TailwindBuilder
 {
     private ?SymfonyStyle $output = null;
     private readonly array $inputPaths;

--- a/src/TailwindVersionFinder.php
+++ b/src/TailwindVersionFinder.php
@@ -15,7 +15,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Finds the latest Tailwind CSS version by major version.
  *
- * @author Kevin Bond <ryan@symfonycasts.com>
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
  */
 final class TailwindVersionFinder
 {

--- a/tests/AssetMapper/TailwindCssAssetCompilerTest.php
+++ b/tests/AssetMapper/TailwindCssAssetCompilerTest.php
@@ -12,22 +12,36 @@ namespace Symfonycasts\TailwindBundle\Tests\AssetMapper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\MappedAsset;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfonycasts\TailwindBundle\AssetMapper\TailwindCssAssetCompiler;
 use Symfonycasts\TailwindBundle\TailwindBuilder;
 
 class TailwindCssAssetCompilerTest extends TestCase
 {
+    private string $varDir;
+
+    protected function setUp(): void
+    {
+        $this->varDir = __DIR__.'/../fixtures/var/tailwind';
+        $fs = new Filesystem();
+        $fs->mkdir($this->varDir);
+        $fs->dumpFile($this->varDir.'/app.built.css', 'output content from Tailwind');
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->varDir);
+    }
+
     public function testCompile(): void
     {
-        $builder = $this->createMock(TailwindBuilder::class);
-        $builder->expects($this->any())
-            ->method('getInputCssPaths')
-            ->willReturn([realpath(__DIR__.'/../fixtures/assets/styles/app.css')]);
-        $builder->expects($this->once())
-            ->method('getInternalOutputCssPath');
-        $builder->expects($this->once())
-            ->method('getOutputCssContent')
-            ->willReturn('output content from Tailwind');
+        $projectDir = realpath(__DIR__.'/../fixtures');
+        $builder = new TailwindBuilder(
+            $projectDir,
+            [$projectDir.'/assets/styles/app.css'],
+            $this->varDir,
+            binaryVersion: 'v3.4.17',
+        );
 
         $compiler = new TailwindCssAssetCompiler($builder);
         $asset1 = new MappedAsset('styles/other.css', __DIR__.'/../fixtures/assets/styles/other.css');

--- a/tests/fixtures/TailwindTestKernel.php
+++ b/tests/fixtures/TailwindTestKernel.php
@@ -47,7 +47,7 @@ class TailwindTestKernel extends Kernel
         parent::boot();
 
         if (null !== $this->versionFinderReleases) {
-            $this->container->set('tailwind.version_finder', new TailwindVersionFinder($this->mockHttpClient()));
+            $this->container->set('.tailwind.version_finder', new TailwindVersionFinder($this->mockHttpClient()));
         }
     }
 
@@ -83,7 +83,7 @@ class TailwindTestKernel extends Kernel
 
         if (null !== $this->versionFinderReleases) {
             // declared synthetic so the real instance (with a mock client) can be set in boot()
-            $container->register('tailwind.version_finder', TailwindVersionFinder::class)
+            $container->register('.tailwind.version_finder', TailwindVersionFinder::class)
                 ->setSynthetic(true)
                 ->setPublic(true);
         }


### PR DESCRIPTION
This pull request introduces several improvements focused on tightening the internal encapsulation of services and classes, as well as improving test reliability and accuracy. The main changes include marking several classes as `final` and `@internal`, updating service definitions to use private (dot-prefixed) service IDs, and enhancing the test setup for more realistic integration.