### PR TITLE
Remind users to clear the cache after config changes

### DIFF
--- a/src/Command/TailwindInitCommand.php
+++ b/src/Command/TailwindInitCommand.php
@@ -69,6 +69,7 @@ final class TailwindInitCommand extends TailwindConfigCommand
         $this->addTailwindDirectives($io, $builder);
 
         $io->success('Tailwind CSS is ready to use!');
+        $io->warning('Run "php bin/console cache:clear" so the updated configuration is picked.');
 
         return self::SUCCESS;
     }

--- a/src/Command/TailwindUpdateCommand.php
+++ b/src/Command/TailwindUpdateCommand.php
@@ -65,7 +65,8 @@ final class TailwindUpdateCommand extends TailwindConfigCommand
         $this->writeBundleConfig($bundleConfig);
 
         $io->success(\sprintf('Tailwind CSS updated from %s to %s!', $this->binaryVersion, $latestVersion));
-        $io->note('If "tailwind:build --watch" is running, restart it to use the new version.');
+        $io->warning('Run "php bin/console cache:clear" so the updated configuration is picked up.');
+        $io->warning('If "tailwind:build --watch" is running, restart it to use the new version.');
 
         return self::SUCCESS;
     }


### PR DESCRIPTION
`tailwind:init` and `tailwind:update` write `config/packages/symfonycasts_tailwind.yaml`, but the container caches that config — so a later `tailwind:build` keeps using the old `binary_version` until the cache is cleared. That's what bit the reporter in #135: they chose v4 during `init`, but `build` still downloaded v3.14.

Both commands now warn the user to run `php bin/console cache:clear` after writing the config.

Closes #135